### PR TITLE
Fatal Exception: java.lang.NullPointerException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 

--- a/stickyscrollview/src/main/java/com/github/nitrico/stickyscrollview/StickyScrollView.java
+++ b/stickyscrollview/src/main/java/com/github/nitrico/stickyscrollview/StickyScrollView.java
@@ -329,11 +329,13 @@ public class StickyScrollView extends NestedScrollView {
 
     private void startStickingView(View viewThatShouldStick) {
         currentlyStickingView = viewThatShouldStick;
-        if (getStringTagForView(currentlyStickingView).contains(FLAG_HASTRANSPARENCY)) {
-            hideView(currentlyStickingView);
-        }
-        if (((String) currentlyStickingView.getTag()).contains(FLAG_NONCONSTANT)) {
-            post(invalidateRunnable);
+        if (currentlyStickingView != null && currentlyStickingView.getTag() != null) {
+            if (getStringTagForView(currentlyStickingView).contains(FLAG_HASTRANSPARENCY)) {
+                hideView(currentlyStickingView);
+            }
+            if (((String) currentlyStickingView.getTag()).contains(FLAG_NONCONSTANT)) {
+                post(invalidateRunnable);
+            }
         }
     }
 


### PR DESCRIPTION
Was receiving a crash report with a %0.07 occurrence (which results in a few hundred crashes due to the user volume of our app):

Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.contains(java.lang.CharSequence)' on a null object reference
       at com.github.nitrico.stickyscrollview.StickyScrollView.startStickingView(Unknown Source)
       at com.github.nitrico.stickyscrollview.StickyScrollView.doTheStickyThing(Unknown Source)
       at com.github.nitrico.stickyscrollview.StickyScrollView.onScrollChanged(Unknown Source)
       at android.view.View.scrollTo(View.java:11436)
       at android.support.v4.widget.NestedScrollView.scrollTo(Unknown Source)
       at android.support.v4.widget.NestedScrollView.onLayout(Unknown Source)
       at com.github.nitrico.stickyscrollview.StickyScrollView.onLayout(Unknown Source)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1705)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1559)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1468)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:573)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:508)
       at android.view.View.layout(View.java:15657)
       at android.view.ViewGroup.layout(ViewGroup.java:4969)
       at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2102)
       at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1859)
       at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1078)
       at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5885)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
       at android.view.Choreographer.doCallbacks(Choreographer.java:580)
       at android.view.Choreographer.doFrame(Choreographer.java:550)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5376)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:908)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:703)